### PR TITLE
Tweak symbolic execution parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ usage: karl.py [-h]
                [--sandbox SANDBOX] [--timeout SECONDS] [--tx-count NUMBER]
                [--modules [MODULES [MODULES ...]]]
                [--onchain-storage ONCHAIN_STORAGE]
-               [--max-vm-depth MAX_VM_DEPTH] [--verbose] [--version]
+               [--loop bound LOOP_BOUND] [--verbose] [--version]
 
 Smart contract monitor using Mythril to find exploits
 
@@ -96,10 +96,9 @@ Scan options:
                         'suicide'])
   --onchain-storage ONCHAIN_STORAGE
                         Whether onchain access should be done or not (default:
-                        False)
-  --max-vm-depth MAX_VM_DEPTH
-                        Maximum execution depth for the vm (default: 32)
-
+                        True)
+  --loop-bound LOOP_BOUND
+                        Bound on number of loop iterations
 Verbosity:
   --verbose, -v         Set verbose (default: 4)
 ```

--- a/karl/interfaces/cli.py
+++ b/karl/interfaces/cli.py
@@ -67,6 +67,13 @@ def main():
         type=int,
     )
     scan_options.add_argument(
+        "--loop-bound",
+        help="Maximum number of loop iterations",
+        metavar="LOOP_BOUND",
+        default=3,
+        type=int,
+    )
+    scan_options.add_argument(
         "--tx-count",
         help="Maximum number of transactions",
         metavar="NUMBER",
@@ -82,14 +89,8 @@ def main():
     scan_options.add_argument(
         "--onchain-storage",
         help="Whether onchain access should be done or not",
-        default=False,
+        default=True,
         type=str2bool,
-    )
-    scan_options.add_argument(
-        "--max-vm-depth",
-        help="Maximum execution depth for the vm",
-        default=32,
-        type=int,
     )
 
     # Verbosity
@@ -160,7 +161,7 @@ def main():
             tx_count=args.tx_count,
             modules=args.modules,
             onchain_storage=args.onchain_storage,
-            max_vm_depth=args.max_vm_depth,
+            loop_bound=args.loop_bound,
         )
         karl.run(forever=True)
     except Exception as e:

--- a/karl/karl.py
+++ b/karl/karl.py
@@ -31,8 +31,8 @@ class Karl:
         timeout=600,
         tx_count=3,
         modules=["ether_thief", "selfdestruct"],
-        onchain_storage=False,
-        max_vm_depth=32,
+        onchain_storage=True,
+        loop_bound=3,
     ):
         """
             Initialize Karl with the received parameters
@@ -55,7 +55,7 @@ class Karl:
         self.tx_count = tx_count
         self.modules = modules
         self.onchain_storage = onchain_storage
-        self.max_vm_depth = max_vm_depth
+        self.loop_bound = 3
 
         # ! hack to stop mythril logging
         logging.getLogger("mythril").setLevel(logging.CRITICAL)
@@ -204,7 +204,8 @@ class Karl:
             disassembler=disassembler,
             address=contract_address,
             execution_timeout=self.timeout,
-            max_depth=self.max_vm_depth,
+            loop_bound=self.loop_bound,
+            max_depth=64,
             create_timeout=10,
         )
 


### PR DESCRIPTION
Update symbolic execution parameters to improve false positive / negative rate:

- Set loop bound instead of max_depth (will be deprecated in the future)
- Activate on-chain storage access by default