### PR TITLE
Installation issue: does not find `persistent` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ eth-tester==0.1.0b32
 eth-typing>=2.0.0
 eth-utils>=1.0.1
 python-dateutil==2.8.0
+z3-solver


### PR DESCRIPTION
```console
karl --help
Traceback (most recent call last):
  File "/home/karl --help
Traceback (most recent call last):
  File "/home/terror/.local/bin/karl", line 5, in <module>
    from karl.interfaces.cli import main
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/interfaces/cli.py", line 5, in <module>
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/output/stdout.py", line 4, in <module>
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/output/output.py", line 2, in <module>
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/analysis/report.py", line 9, in <module>
    from mythril.solidity.soliditycontract import SolidityContract
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/solidity/soliditycontract.py", line 6, in <module>
    from mythril.ethereum.evmcontract import EVMContract
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/ethereum/evmcontract.py", line 5, in <module>
    import persistent
ImportError: No module named 'persistent'
/.local/bin/karl", line 5, in <module>
    from karl.interfaces.cli import main
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/interfaces/cli.py", line 5, in <module>
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/output/stdout.py", line 4, in <module>
  File "/usr/local/lib/python3.5/dist-packages/karl-0.8.0-py3.5.egg/karl/output/output.py", line 2, in <module>
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/analysis/report.py", line 9, in <module>
    from mythril.solidity.soliditycontract import SolidityContract
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/solidity/soliditycontract.py", line 6, in <module>
    from mythril.ethereum.evmcontract import EVMContract
  File "/usr/local/lib/python3.5/dist-packages/mythril-0.21.19-py3.5.egg/mythril/ethereum/evmcontract.py", line 5, in <module>
    import persistent
ImportError: No module named 'persistent'
```

why ethereum ppl cant write code? i really hope the explanation for this makes some sense
ps doesnt work either with python 3.6